### PR TITLE
Re-record tape if deleted

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,12 +35,14 @@ module.exports = function (host, opts) {
 
       return Promise.try(function () {
         var fileName = require.resolve(file);
-        
+        var err;
+
         // If tape was deleted, then throw module not found error
-        // so that it can be re-recorded instead of failing on 
-        // require.
+        // so that it can be re-recorded instead of failing on
+        // require
         if (!fs.existsSync(fileName)) {
-          var err = new Error('File does not exist');
+          err = new Error('File does not exist');
+
           err.code = 'MODULE_NOT_FOUND';
           throw err;
         }

--- a/index.js
+++ b/index.js
@@ -34,13 +34,13 @@ module.exports = function (host, opts) {
       var file = path.join(opts.dirname, tapename(req, body));
 
       return Promise.try(function () {
-        const fileName = require.resolve(file);
+        var fileName = require.resolve(file);
         
         // If tape was deleted, then throw module not found error
         // so that it can be re-recorded instead of failing on 
         // require.
         if (!fs.existsSync(fileName)) {
-          const err = new Error('File does not exist');
+          var err = new Error('File does not exist');
           err.code = 'MODULE_NOT_FOUND';
           throw err;
         }


### PR DESCRIPTION
If any tapes are deleted while the yakbak server is running in order to refresh them, any subsequent requests for that tape will result in retrieving the cached tape module instead of re-recording. This is because require.resolve does not throw an error even if the tape file doesn't exist and the tape module was cleared from the require.cache.  This, however, causes the require to be called which then throws a file not found error.

A simple fix is to check if the file exists post-request.resolve and to throw a MODULE_NOT_FOUND exception if it doesn't which causes control to pass into the catch(ModuleNotFoundError, ...) block, and the request to be re-recorded.